### PR TITLE
Add Yaml parser to CSV parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CSV Parser in GO
-This is a simple CSV parser written in GO. It reads a CSV file and prints the content to the console or to a text file in JSON format.
+This is a simple CSV parser written in GO. It reads a CSV file and prints the content to the console or to a text file in JSON or Yaml format.
 
 ## How to run
 1. Clone the repository
@@ -10,7 +10,7 @@ go run main.go
 3. The content of the CSV file will be printed to the console.
 
 ## Flag for the cli application
-- `-o` or `--output` : Output the content of the CSV file to a file in JSON format. Example:
+- `-o` or `--output` : Output the content of the CSV file to a file in JSON or Yaml format. Example:
 ```bash
 go run main.go -o output.json
 ```
@@ -21,4 +21,8 @@ go run main.go -h
 - `-delim`: Specify the delimiter of the CSV file. Example:
 ```bash
 go run main.go -delim ; -o output.json
+```
+- `-format`: Specify the output format of the CSV file. Use `json` or `yaml`. Example:
+```bash
+go run main.go -format yaml -o output.yaml
 ```

--- a/json_parser.go
+++ b/json_parser.go
@@ -1,0 +1,25 @@
+package json_parser
+
+import (
+    "encoding/json"
+    "os"
+)
+
+func ConvertToJSON(data []map[string]string) ([]byte, error) {
+    return json.MarshalIndent(data, "", "    ")
+}
+
+func WriteJSONFile(jsonData []byte, outFile string) error {
+    file, err := os.Create(outFile)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    _, err = file.Write(jsonData)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}

--- a/yaml_parser.go
+++ b/yaml_parser.go
@@ -1,0 +1,25 @@
+package yaml_parser
+
+import (
+    "gopkg.in/yaml.v2"
+    "os"
+)
+
+func ConvertToYAML(data []map[string]string) ([]byte, error) {
+    return yaml.Marshal(data)
+}
+
+func WriteYAMLFile(yamlData []byte, outFile string) error {
+    file, err := os.Create(outFile)
+    if err != nil {
+        return err
+    }
+    defer file.Close()
+
+    _, err = file.Write(yamlData)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}


### PR DESCRIPTION
Fixes #1

Add support for converting CSV files to Yaml format.

* **main.go**: Remove JSON conversion logic and move it to `json_parser.go`. Import `json_parser` and `yaml_parser` packages. Add logic to call appropriate parser based on flags. Refactor flagging to use a single `-format` flag with values `json` or `yaml`.
* **README.md**: Update instructions to include Yaml output option. Update instructions to use the new `-format` flag.
* **json_parser.go**: Add new file to handle JSON conversion. Import `encoding/json` package. Add function `ConvertToJSON` to handle JSON conversion. Add function `WriteJSONFile` to write JSON data to file.
* **yaml_parser.go**: Add new file to handle Yaml conversion. Import `gopkg.in/yaml.v2` package. Add function `ConvertToYAML` to handle Yaml conversion. Add function `WriteYAMLFile` to write Yaml data to file.